### PR TITLE
Fix problem with whitespace character in $WINPTY_DIR 

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -27,7 +27,7 @@ if [[ -z $BABUN_DOCKER_SETUP ]] ; then
   chmod 777 $WINPTY_DIR/*
   # Add winpty to the PATH
   echo '# Add Winpty fix for Docker' >> ~/.zshrc
-  echo 'PATH=$PATH:'$WINPTY_DIR >> ~/.zshrc
+  echo 'PATH=$PATH:'\"$WINPTY_DIR\" >> ~/.zshrc
   echo '
 # Fix for Docker and Docker Toolbox in Babun
 if [[ -z "$docker_bin" ]] then ;


### PR DESCRIPTION
Having a `$HOME` path with spaces in it caused problems when appending `$WINPTY_DIR` to `$PATH`. With this fix it works on my machine, where `$HOME` is `/home/Lars Kinn Ekroll`.
