### PR TITLE
Support the error interface in docker v1.10

### DIFF
--- a/bin/babun-docker.sh
+++ b/bin/babun-docker.sh
@@ -15,7 +15,7 @@ function docker {
    echo $line
     if [[ $line == "cannot enable tty mode on non tty input" ]] ; then
       babun_docker_use_winpty=1
-    elif [[ $line == *"ConnectEx tcp"* ]] ; then
+    elif [[ $line == *"ConnectEx tcp"* || $line == *"connectex"* ]] ; then
       # Set up shared folders in VirtualBox
       if [[ $babun_docker_setup_volumes == 1 ]] ; then
         IFS=$babun_docker_old_IFS


### PR DESCRIPTION
The connection error is changed to something like..

> An error occurred trying to connect: Get http://127.0.0.1:2375/v1.22/containers/json: dial tcp 127.0.0.1:2375: connectex: No connection could be made because the target machine actively refused it.

```
docker version
Client:
 Version:      1.10.2
 API version:  1.22
 Go version:   go1.5.3
 Git commit:   c3959b1
 Built:        Mon Feb 22 22:37:33 2016
 OS/Arch:      windows/amd64
```
