### PR TITLE
Use `-O` with `wget` to be explicit about the output file name

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -38,7 +38,7 @@ if [[ ! -f $babun_docker_winpty_filename ]] ; then
    mkdir -p $babun_docker_winpty_dir
    cd $babun_docker_winpty_dir
    # Download winpty
-   wget $babun_docker_winpty_url
+   wget $babun_docker_winpty_url -O $babun_docker_winpty_filename
    # Untar the downloaded file
    tar xf $babun_docker_winpty_filename
    # Move the tar contents to the current directory


### PR DESCRIPTION
When I first tried running your `setup.sh`, the script would exit early with the error:

```
tar: winpty-0.2.2-cygwin-2.4.1-ia32.tar.gz: Cannot open: No such file or directory
```

Looking further up in the output, I noticed that `wget` was saving the file as some crazy long filename. I added the `-O` flag with an explicit file name, and then it worked.
